### PR TITLE
Update test-and-release.yml - fix master/main

### DIFF
--- a/.github/workflows/test-and-release.yml
+++ b/.github/workflows/test-and-release.yml
@@ -5,7 +5,7 @@ name: Test and Release
 on:
     push:
         branches:
-            - 'main'
+            - 'master'
         tags:
             # normal versions
             - 'v[0-9]+.[0-9]+.[0-9]+'


### PR DESCRIPTION
Your standard github based tests are not functional as the main branche naming did not match.
This PR adjust the workflow to the name of your head branch.